### PR TITLE
fix repo name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ These are the steps to get the app up and running:
 Make a local copy of this project and move into the directory. This project requires Ruby and RubyGems.
 ```
   $ git clone https://github.com/nlaz/whosebioisitanyway.git
-  $ cd starbot
+  $ cd whosebioisitanyway
 ```
 
 ### Step 2. Connect your twitter app


### PR DESCRIPTION
Previously said `cd starbot`, changed to `cd whosebioisitanyway`. Must've been leftover from an old project.
